### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/project-board/src/main/java/com/portfolio/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/portfolio/projectboard/domain/Article.java
@@ -1,17 +1,10 @@
 package com.portfolio.projectboard.domain;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/project-board/src/main/java/com/portfolio/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/portfolio/projectboard/domain/ArticleComment.java
@@ -3,13 +3,8 @@ package com.portfolio.projectboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter

--- a/project-board/src/main/java/com/portfolio/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/portfolio/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.portfolio.projectboard.repository;
 
 import com.portfolio.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/project-board/src/main/java/com/portfolio/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/portfolio/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.portfolio.projectboard.repository;
 
 import com.portfolio.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/project-board/src/test/java/com/portfolio/projectboard/controller/DataRestTest.java
+++ b/project-board/src/test/java/com/portfolio/projectboard/controller/DataRestTest.java
@@ -1,0 +1,89 @@
+package com.portfolio.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void gwt_article_list() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")))
+                .andDo(print());
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void gwt_article_page() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")))
+                .andDo(print());
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void gwt_article_comment_list() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")))
+                .andDo(print());
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void gwt_comment_list() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")))
+                .andDo(print());
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void gwt_comment() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크 하게 끔 통합 테스트 작성